### PR TITLE
set tag should not increase indent of next line

### DIFF
--- a/indent/htmljinja.vim
+++ b/indent/htmljinja.vim
@@ -43,7 +43,7 @@ function! GetJinjaIndent(...)
   let tagstart = '.*' . '{%\s*'
   let tagend = '.*%}' . '.*'
 
-  let blocktags = '\(block\|for\|if\|with\|autoescape\|filter\|trans\|macro\|set\)'
+  let blocktags = '\(block\|for\|if\|with\|autoescape\|filter\|trans\|macro\)'
   let midtags = '\(else\|elif\|pluralize\)'
 
   let pnb_blockstart = pnb =~# tagstart . blocktags . tagend


### PR DESCRIPTION
The code example [here](http://jinja.pocoo.org/docs/templates/#with-statement) shows the correct indention where `{% set foo = 42 %}` does not increase the indention of the next line `{{ foo }}`.
