### PR TITLE
Checking existence of b:did_jinja_autodetect variable

### DIFF
--- a/plugin/htmljinja.vim
+++ b/plugin/htmljinja.vim
@@ -56,7 +56,9 @@ fun! s:ConsiderSwitchingToJinja()
 endfun
 
 fun! s:ConsiderSwitchingToJinjaAgain()
-  unlet b:did_jinja_autodetect
+  if exists("b:did_jinja_autodetect")
+    unlet b:did_jinja_autodetect
+  endif
   call s:TryDetectJinja()
 endfun
 


### PR DESCRIPTION
I’m getting this error when saving:

```
"public/javascripts/daily-domo/start/dd-start.html" 41L, 886C written                                                                                                                                                                         
Error detected while processing function <SNR>44_ConsiderSwitchingToJinjaAgain:                                                                                                                                                               
line    2:                                                                                                                                                                                                                                    
E108: No such variable: "b:did_jinja_autodetect"                                                                                                                                                                                              
Press ENTER or type command to continue                                                                                                                                                                                                      
```

This is my setup:

``` viml
au BufNewFile,BufRead *.html set ft=htmljinja
```

And to reproduce:
- open a file that uses the plugin
- open a second file that uses the plugin
- save this file
- observe error

I could be doing something wrong; Perhaps I need to enable the plugin for `.html` file in a different way, or maybe not. Patch does prevent error from being thrown and does not seem to affect the plugin in a negative way. Let me know what you think - and thanks for the plugin.
