### PR TITLE
Fix error on save when filename doesn't match filetype

### DIFF
--- a/plugin/htmljinja.vim
+++ b/plugin/htmljinja.vim
@@ -56,8 +56,10 @@ fun! s:ConsiderSwitchingToJinja()
 endfun
 
 fun! s:ConsiderSwitchingToJinjaAgain()
-  unlet b:did_jinja_autodetect
-  call s:TryDetectJinja()
+  if exists("b:did_jinja_autodetect")
+    unlet b:did_jinja_autodetect
+    call s:TryDetectJinja()
+  endif
 endfun
 
 autocmd FileType htmldjango call s:ConsiderSwitchingToJinja()


### PR DESCRIPTION
When a file has the .html extension but is not given the html filetype
(e.g. because it got the xhtml filetype), the BufWritePost autocommand
would try to unlet a non-existent variable, triggering error E108.

Fixes #6.
