### PR TITLE
fix: can't not detect the filetype when the file has only one line.

### DIFF
--- a/plugin/htmljinja.vim
+++ b/plugin/htmljinja.vim
@@ -24,7 +24,7 @@ fun! s:TryDetectJinja()
   let b:did_jinja_autodetect=1
 
   let n = 1
-  while n < 50 && n < line("$")
+  while n < 50 && n <= line("$")
     let line = getline(n)
     if line =~ '{%\s*\(extends\|block\|macro\|set\|if\|for\|include\|trans\)\>' || line =~ '{{\s*\S+[|(]'
       setlocal filetype=htmljinja


### PR DESCRIPTION
when the file only has one line, the condition for the loop to detect
filetype is false, and it will never work.